### PR TITLE
Add color to the Ypsilon Empire

### DIFF
--- a/_data/alliances.yaml
+++ b/_data/alliances.yaml
@@ -120,6 +120,7 @@ ud:
 ypsilonempire:
   name: Ypsilon Empire
   abbreviation: Ypsilon
+  color: "#0066ff"
   members:
   - daboross
   - DoctorPC


### PR DESCRIPTION
Add the official Ypsilon Empire color (#0066ff blue) as the map color. 
